### PR TITLE
Implemented Clone for `NamedField`s

### DIFF
--- a/src/dynamic_value.rs
+++ b/src/dynamic_value.rs
@@ -26,6 +26,18 @@ pub struct NamedField<I> {
     pub value: I,
 }
 
+impl<I> Clone for NamedField<I>
+where
+    I: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
 impl<I> DynamicRow<I> {
     pub fn get(&self, index: usize) -> Option<&I> {
         self.values.get(index)

--- a/src/dynamic_value.rs
+++ b/src/dynamic_value.rs
@@ -15,27 +15,15 @@ impl diesel::sql_types::HasSqlType<Any> for diesel::mysql::Mysql {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DynamicRow<I> {
     values: Vec<I>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NamedField<I> {
     pub name: String,
     pub value: I,
-}
-
-impl<I> Clone for NamedField<I>
-where
-    I: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            name: self.name.clone(),
-            value: self.value.clone(),
-        }
-    }
 }
 
 impl<I> DynamicRow<I> {


### PR DESCRIPTION
This implements `std::clone::Clone` for `NamedField`s, if the inner type is `Clone`. This allows chaining with #1, to easily do transformations in returned rows.